### PR TITLE
Fix eneba_spider black_list argument +patch

### DIFF
--- a/GameFinder/spiders/eneba_spider.py
+++ b/GameFinder/spiders/eneba_spider.py
@@ -69,7 +69,12 @@ class EnebaSpider(scrapy.Spider):
             yield scrapy.Request(next_page, callback=self.parse)
     
     def get_blacklist(self):
-        return getattr(self, "blacklist", "").split(",")
+        black_list = getattr(self, "blacklist", None)
+        
+        if not black_list:
+            return []
+        
+        return black_list.split(",")
 
 
 def process_pictures(pictures):


### PR DESCRIPTION
eneba spider uses black_list argumento to avoid certain items using a fallback value that was a empty string that yield a list with a single value (a empty string) thus avoiding every single game